### PR TITLE
Peer dependency fix 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,9 +169,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash._baseassign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
       }
     },
     "coffee-script": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-      "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=",
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
       "dev": true
     },
     "commander": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/srgraham/coffeelint-callback-handle-error",
   "peerDependencies": {
-    "coffee-script": "1.10.0"
+    "coffee-script": ">=1.11.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "coffee-script": "1.10.0",
+    "coffee-script": ">=1.11.0",
     "lodash": "^4.17.11",
     "mocha": "^3.5.3"
   }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/srgraham/coffeelint-callback-handle-error",
   "peerDependencies": {
-    "coffee-script": ">=1.11.0"
+    "coffee-script": "^1.11.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "coffee-script": ">=1.11.0",
-    "lodash": "^4.17.11",
+    "coffee-script": "^1.11.0",
+    "lodash": "^4.17.21",
     "mocha": "^3.5.3"
   }
 }


### PR DESCRIPTION
The Digit repo has moved to coffeescript `1.11.0` causing the demand for `1.10.0` in this package to fail.
This change updates the dep requirement and runs `audit --fix`